### PR TITLE
Improve client-only resolver check

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project contains a small HTML and JavaScript application for verifying whic
 
 1. Upload the files in this repository to your own GitHub repository.
 2. Enable **GitHub Pages** in the repository settings.
-3. Navigate to `https://caripson.github.io/dns-checker/` to load the page.
+3. Navigate to `https://caripson.github.io/dns-checker/` (or the URL of your fork) to load the page.
 
 ## Configuring your trusted resolvers
 
@@ -23,19 +23,19 @@ Open `script.js` and modify the `trustedResolvers` array. Add every resolver IP 
 const trustedResolvers = ['1.1.1.1', '1.0.0.1']; // Add your resolvers here
 ```
 
-## Running the local test server
+## Running the optional local test server
 
-To detect the actual DNS resolver used by your device, start the included
-Node.js server and open the page through it. The server proxies requests to
-`bash.ws` and avoids cross-origin restrictions.
+For the GitHub Pages version the browser queries `resolver.dnscrypt.info` via
+Cloudflare to reveal the resolver IP. If you want to perform the more extensive
+`bash.ws` leak test locally you can run the included Node.js proxy:
 
 ```bash
 npm install
 node server.js
 ```
 
-Then navigate to `http://localhost:3000` on your iPhone and click **Check my
-resolver**. The page will display the DNS servers observed by `bash.ws`.
+Open `http://localhost:3000` and click **Check my resolver**. The page will show
+the DNS servers detected by `bash.ws`.
 
 ## Design changes
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <p class="text-light">Buttons can be transparent with an outline.</p>
     <button class="btn-outline">Outlined Action</button>
   </div>
-  <script src="resolver-check.js"></script>
-  <!-- Resolver checking logic lives in resolver-check.js -->
+  <script src="script.js"></script>
+  <!-- Resolver checking logic lives in script.js -->
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -19,23 +19,26 @@ document.getElementById("checkBtn").addEventListener("click", () => {
           dns = match[1];
         }
       }
-      statusDiv.textContent += ` (Resolver: ${dns})`;
-
-
       // List of resolvers considered safe - edit to match your own
-      //const trustedResolvers = ['1.2.3.4', 'dns.safesurf.se'];
-      const trustedResolvers = ['192.178.94.20','192.178.94.24','2a00:1450:4025:3c03::127','2a00:1450:4025:3c03::124','2a00:1450:4025:3c05::12a','104.23.222.24','162.158.180.203','162.158.180.203'];
-  
+      const trustedResolvers = [
+        '192.178.94.20',
+        '192.178.94.24',
+        '2a00:1450:4025:3c03::127',
+        '2a00:1450:4025:3c03::124',
+        '2a00:1450:4025:3c05::12a',
+        '104.23.222.24',
+        '162.158.180.203'
+      ];
 
-      // Display message based on whether the resolver is trusted
       // Reset any previous status classes
       statusDiv.classList.remove('text-success', 'text-danger', 'text-warning');
 
+      // Display the resolver and whether it is trusted
       if (trustedResolvers.includes(dns)) {
-        statusDiv.textContent = `✅ You are protected (Resolver: ${dns})`;
+        statusDiv.textContent = `Resolver: ${dns} - \u2705 Trusted`;
         statusDiv.classList.add('text-success');
       } else {
-        statusDiv.textContent = `⚠️ You are not protected (Resolver: ${dns})`;
+        statusDiv.textContent = `Resolver: ${dns} - \u274C Untrusted`;
         statusDiv.classList.add('text-danger');
       }
     })


### PR DESCRIPTION
## Summary
- show the resolver IP and mark as trusted/untrusted in `script.js`
- load the client script from `index.html`
- clarify README for GitHub Pages usage and optional Node proxy

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68480f073da8832aa027a41f660e99e6