### PR TITLE
Refactor: Remove misleading resolver check & add guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,19 @@
 
     <ul id="results"></ul>
 
-    <hr>
-    <button id="checkBtn" class="btn">Check my resolver</button>
-    <div id="status" class="text-large">Status: Not checked yet.</div>
+    <div class="resolver-info" style="text-align: left; margin-top: 2rem;">
+      <h3>Hur kontrollerar jag vilken DNS-resolver jag använder?</h3>
+      <p>
+        Den här sidan kan inte automatiskt identifiera DNS-resolvern som är konfigurerad på din enhet (t.ex. din iPhone eller dator). Detta beror på säkerhetsbegränsningar i webbläsare.
+      </p>
+      <p>
+        För att se vilken DNS-resolver du använder:
+      </p>
+      <ul>
+        <li>Kontrollera nätverksinställningarna på din enhet.</li>
+        <li>Du kan också använda en extern onlinetjänst. Exempel på sådana tjänster är <code>dnsleaktest.com</code> eller <code>whatsmydnsserver.com</code>. (Observera: vi är inte ansvariga för innehållet på externa webbplatser).</li>
+      </ul>
+    </div>
   </div>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -6,7 +6,6 @@
 // Initialize the page after DOM is ready
 function init() {
   getEl('dnsBtn').addEventListener('click', checkDNS);
-  getEl('checkBtn').addEventListener('click', checkMyResolver);
 }
 
 document.addEventListener('DOMContentLoaded', init);
@@ -124,82 +123,6 @@ function checkDNS() {
       displayError('Error fetching DNS');
       toggleLoading(false);
     });
-}
-
-// --- Resolver check functionality ---
-
-// Fetch the resolver IP from the special TXT record
-function checkMyResolver() {
-  const status = getEl('status');
-  status.className = 'text-large';
-  setText(status, 'Checking...');
-  fetch('https://cloudflare-dns.com/dns-query?name=resolver.dnscrypt.info&type=TXT', {
-    headers: { 'Accept': 'application/dns-json' }
-  })
-    .then(r => r.json())
-    .then(data => {
-      const ip = parseResolverIp(data);
-      updateResolverStatus(ip);
-    })
-    .catch(() => {
-      status.className = 'text-large text-warning';
-      setText(status, 'An error occurred while checking.');
-    });
-}
-
-// Extract resolver IP from DNS response
-function parseResolverIp(data) {
-  if (data.Answer && data.Answer.length > 0) {
-    const txt = data.Answer[0].data.replace(/"/g, '');
-    const match = txt.match(/Resolver IP:\s*([^\s]+)/i);
-    if (match) return match[1];
-  }
-  return 'Unknown';
-}
-
-// Update the resolver status element with result
-function updateResolverStatus(ip) {
-  const status = getEl('status');
-  status.classList.remove('text-success', 'text-danger', 'text-warning');
-  if (isTrustedResolver(ip)) {
-    status.classList.add('text-success');
-    setText(status, `Resolver: ${ip} - \u2705 Trusted`);
-  } else {
-    status.classList.add('text-danger');
-    setText(status, `Resolver: ${ip} - \u274C Untrusted`);
-  }
-}
-
-// Get list of trusted resolvers
-function getTrustedResolvers() {
-  return [
-    '192.178.94.20',
-    '192.178.94.24',
-    '2a00:1450:4025:3c03::127',
-    '2a00:1450:4025:3c03::124',
-    '2a00:1450:4025:3c05::12a',
-    '104.23.222.24',
-    '162.158.180.203',
-    '8.8.8.8'
-  ];
-}
-
-// Determine if a resolver IP is trusted
-function isTrustedResolver(ip) {
-  return getTrustedResolvers().includes(ip);
-}
-
-// Add a resolver IP to the trusted list (not persisted)
-function addTrustedResolver(ip) {
-  const list = getTrustedResolvers();
-  if (!list.includes(ip)) list.push(ip);
-}
-
-// Remove a resolver IP from the trusted list (not persisted)
-function removeTrustedResolver(ip) {
-  const list = getTrustedResolvers();
-  const idx = list.indexOf(ip);
-  if (idx > -1) list.splice(idx, 1);
 }
 
 // Format IPv4/IPv6 address (placeholder for future logic)


### PR DESCRIPTION
The previous "Check my resolver" functionality did not detect your system DNS resolver. Instead, it queried Cloudflare's DoH service and displayed Cloudflare's IP address. This could be misleading for you if you were trying to verify your own device's DNS configuration.

This commit addresses the issue by:
1. Removing the "Check my resolver" button and its associated JavaScript code (`checkMyResolver`, `parseResolverIp`, etc.).
2. Adding a new section in `index.html` (in Swedish) that explains:
    - Why client-side JavaScript cannot directly detect system DNS resolvers.
    - How you can check your DNS resolver settings manually via your device's network settings or by using reputable third-party online tools.

This change aims to provide accurate information and prevent confusion.